### PR TITLE
Make jumping case-sensitive even with noignorecase

### DIFF
--- a/plugin/kweasy.vim
+++ b/plugin/kweasy.vim
@@ -2,7 +2,7 @@
 " Maintainer:	Barry Arthur <barry.arthur@gmail.com>
 " Version:	0.3
 " Description:	Jump to the object you're looking at!
-" Last Change:	2014-03-27
+" Last Change:	2014-08-11
 " License:	Vim License (see :help license)
 " Location:	plugin/kweasy.vim
 " Website:	https://github.com/dahu/kweasy
@@ -139,7 +139,7 @@ function! s:jump_marks_overlay(lines, cur_pos)
   let jump = escape(nr2char(getchar()), '^$.*~]\\')
   if jump == '' || jump == "\<esc>" || jump == "\<cr>"
     let jump_pos = cur_pos
-  elseif search(jump, 'cW') == 0
+  elseif search(jump . '\C', 'cW') == 0
     let jump_pos = cur_pos
   else
     let jump_pos = getpos('.')


### PR DESCRIPTION
If you have :set ignorecase, and search for a fairly common character, like 'e', and the jump characters go all the way to ABCDE..., then hitting A, for example, will take you to the character under 'a' instead of the one you're looking at, which makes me a little _too_ kweasy and means I often can't jump to the latter half of my screen.
All that's needed to fix it is to make it so the search on the jump screen (NOT the original search, that one is already case sensitive when it needs to be) is mandated case-sensitive regardless of user settings.

Cheers!
